### PR TITLE
fix build_webrtc_linux_client_sdk.sh silent fail on 2nd run

### DIFF
--- a/WebRTC-Sample/owt-linux-player/build_webrtc_linux_client_sdk.sh
+++ b/WebRTC-Sample/owt-linux-player/build_webrtc_linux_client_sdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 ROOT=`pwd`/webrtc_linux_client_sdk
 BUILD=${ROOT}/Build
@@ -101,6 +101,7 @@ install_owt_client_native () {
     cd owt-client-native
     gen_gclient
 
+    rm -fr src
     git clone https://github.com/open-webrtc-toolkit/owt-client-native.git src
     cd src
     git checkout 2a9d948b59502559843d63775a395affb10cb128


### PR DESCRIPTION
root cause:

$ ./build_webrtc_linux_client_sdk.sh
 1st run, git clone owt_client_native ok

$ ./build_webrtc_linux_client_sdk.sh
 2nd run, git clone fails due to folder already exist
 however it failed silently

fix: #!/bin/bash -e  to avoid silent fails
and git pull only if git already cloned