### PR TITLE
Fix Travis CI build fail issue.

### DIFF
--- a/src/external/build.sh
+++ b/src/external/build.sh
@@ -45,6 +45,10 @@ build_client(){
 build_ci(){
     source /opt/rh/devtoolset-7/enable
     PREBUILD_FLAG="n"
+    sudo cp ../ffmpeg/dependency/*.so /usr/local/lib/
+    sudo cp ../ffmpeg/dependency/*.pc /usr/local/lib/pkgconfig/
+    sudo cp ../ffmpeg/dependency/*.h /usr/local/include/
+    sudo cp ../ffmpeg/dependency/WorkerServer /root
 
     # Build server
     ./build_Nokia_omaf.sh

--- a/src/external/install_FFmpeg.sh
+++ b/src/external/install_FFmpeg.sh
@@ -24,6 +24,7 @@ if [ ${TARGET} == "server" ] ; then
 elif [ ${TARGET} == "client" ] ; then
 
     patch -p1 < ../ffmpeg/patches/0001-Add-avcodec_receive_frame2-for-vaapi-hardware-decodi.patch
+    cd -
     mkdir -p build/external/ffmpeg_client
     cd build/external/ffmpeg_client
     ../../../FFmpeg/configure --enable-shared


### PR DESCRIPTION
Previous adjustment of CI build process missing installaion of
server dependency, resolved after complement.