### PR TITLE
using timestamp to track frame

### DIFF
--- a/src/360SCVP/360SCVPAPI.h
+++ b/src/360SCVP/360SCVPAPI.h
@@ -164,6 +164,7 @@ typedef struct RECTANGUALAR_REGION_WIZE_PACKING
 //!          of each video stream, including regions number, detailed
 //!          region wise packing information for each region, and so on
 //! add three variables(high resolution region number, low resolution stream width and height) to support WeRTC sample player
+//! add timestamp in SEI to track frame
 //!
 typedef struct REGION_WIZE_PACKING
 {
@@ -177,6 +178,7 @@ typedef struct REGION_WIZE_PACKING
     uint8_t  numHiRegions;
     uint32_t lowResPicWidth;
     uint32_t lowResPicHeight;
+    uint32_t timeStamp;
 }RegionWisePacking;
 
 typedef struct VIEW_PORT
@@ -380,6 +382,7 @@ typedef struct PARAM_STREAMSTITCHINFO
 //! \param    inputLowBistreamLen,input,    the length of the low resolution input bistream, just used in the usedType=E_MERGE_AND_VIEWPORT
 //! \param    pOutputSEI,         output,   the buffer for the output SEI bistream, mainly RWPK, just used in the usedType=E_MERGE_AND_VIEWPORT
 //! \param    outputSEILen,       output,   the length of the output SEI bistream, just used in the usedType=E_MERGE_AND_VIEWPORT
+//! \param    timeStamp,          input,    using timestamp to track frame, especially used in the E_MERGE_AND_VIEWPORT use case
 //!
 typedef struct PARAM_360SCVP
 {
@@ -401,6 +404,7 @@ typedef struct PARAM_360SCVP
     unsigned int           inputLowBistreamLen;
     unsigned char         *pOutputSEI;
     unsigned int           outputSEILen;
+    uint32_t               timeStamp;
 }param_360SCVP;
 
 //!

--- a/src/360SCVP/360SCVPHevcEncHdr.cpp
+++ b/src/360SCVP/360SCVPHevcEncHdr.cpp
@@ -758,6 +758,7 @@ uint32_t writeCubeProjectionSEINal(GTS_BitStream *bs, CubemapProjectionSEI& proj
          gts_bs_write_int(bs, packing.numHiRegions, 8);
          gts_bs_write_int(bs, packing.lowResPicWidth, 32);
          gts_bs_write_int(bs, packing.lowResPicHeight, 32);
+         gts_bs_write_int(bs, packing.timeStamp, 32);
      }
 
      hevc_bitstream_add_rbsp_trailing_bits(bs);
@@ -859,6 +860,7 @@ uint32_t writeCubeProjectionSEINal(GTS_BitStream *bs, CubemapProjectionSEI& proj
      packing.numHiRegions = pRegion->numHiRegions;
      packing.lowResPicWidth = pRegion->lowResPicWidth;
      packing.lowResPicHeight = pRegion->lowResPicHeight;
+     packing.timeStamp = pRegion->timeStamp;
      RectangularRegionWisePacking* inputRegion = pRegion->rectRegionPacking;
      packing.regionsSize = pRegion->numRegions;
      packing.pRegions = new RegionStruct[pRegion->numRegions];

--- a/src/360SCVP/360SCVPHevcParser.cpp
+++ b/src/360SCVP/360SCVPHevcParser.cpp
@@ -1968,6 +1968,7 @@ int32_t hevc_read_RwpkSEI(int8_t *pRWPKBits, uint32_t RWPKBitsSize, RegionWisePa
     pRWPK->numHiRegions = gts_bs_read_int(bs, 8);
     pRWPK->lowResPicWidth = gts_bs_read_int(bs, 32);
     pRWPK->lowResPicHeight = gts_bs_read_int(bs, 32);
+    pRWPK->timeStamp = gts_bs_read_int(bs, 32);
 
 exit:
     if (bs) gts_bs_del(bs);

--- a/src/360SCVP/360SCVPHevcParser.h
+++ b/src/360SCVP/360SCVPHevcParser.h
@@ -187,6 +187,7 @@ struct RegionWisePackingSEI
     uint8_t  numHiRegions;
     uint32_t lowResPicWidth;
     uint32_t lowResPicHeight;
+    uint32_t timeStamp;
 };
 
 struct ViewportStruct

--- a/src/360SCVP/360SCVPImpl.cpp
+++ b/src/360SCVP/360SCVPImpl.cpp
@@ -666,6 +666,7 @@ int32_t TstitchStream::doMerge(param_360SCVP* pParamStitchStream)
     m_dstRwpk.numHiRegions = m_tileWidthCountSel[0] * m_tileHeightCountSel[0];
     m_dstRwpk.lowResPicWidth = mergeStream->lowRes.width;
     m_dstRwpk.lowResPicHeight = mergeStream->lowRes.height;
+    m_dstRwpk.timeStamp = pParamStitchStream->timeStamp;
 
     if (!m_dstRwpk.rectRegionPacking)
     {


### PR DESCRIPTION
using timestamp to track frame, especially in the E_MERGE_AND_VIEWPORT use case

Signed-off-by: Sun, Yanying <yanying.sun@intel.com>