### PR TITLE
upgrade openssl to v1.1.1h

### DIFF
--- a/WebRTC-Sample/owt-linux-player/build_webrtc_linux_client_sdk.sh
+++ b/WebRTC-Sample/owt-linux-player/build_webrtc_linux_client_sdk.sh
@@ -30,12 +30,12 @@ install_dependencies() {
 
 install_openssl() {
     cd ${DEPS}
+    local SSL_VERSION="1_1_1h"
+    rm -rf openssl* OpenSSL*
 
-    rm -rf openssl-1.1.0l.tar.gz openssl-1.1.0l
-
-    wget https://www.openssl.org/source/openssl-1.1.0l.tar.gz
-    tar -zxvf openssl-1.1.0l.tar.gz
-    cd openssl-1.1.0l
+    wget -c https://github.com/openssl/openssl/archive/OpenSSL_${SSL_VERSION}.tar.gz
+    tar xf OpenSSL_${SSL_VERSION}.tar.gz
+    cd openssl-OpenSSL_${SSL_VERSION}
 
     ./config shared -m64 --prefix=${PREFIX} --openssldir=${PREFIX}
     make -j


### PR DESCRIPTION
v1.1.0 seems conflicting with OMAF-Sample libcurl 7.66
when linking render, ld will fail with error message:
 /usr/local/lib/libcurl.so.4 cannot find openssl 1.1.1 function

p.s. download from github is much faster

Signed-off-by: Tiger Meng <xiao.xi.meng@intel.com>